### PR TITLE
Adapt to new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ To collect data, create a pipe that inherits from `learning_pipeline_plugin.coll
 and define `interpret_inputs()`.
 
 Example:
+
 ```python
 from typing import Optional
 from learning_pipeline_plugin.collect_pipe import CollectPipeBase, DataDict
+from learning_pipeline_plugin import sender_task
 
 class CollectPipe(CollectPipeBase):
     def interpret_inputs(self, inputs) -> Optional[DataDict]:
@@ -33,7 +35,16 @@ class CollectPipe(CollectPipeBase):
 - `feature_vector`: vector with shape (N,)
 - `other_data`: any data used for calculating uncertainty
 
-Then, instantiate this and connect to other pipes:
+Then, create a `SenderTask` instance and pass it the pipeline_id parameter corresponding to your pipeline.
+
+```python
+def main():
+    [...]
+
+    sender = sender_task.SenderTask(pipeline_id)
+```
+
+Finally, instantiate your `CollectPipe` and connect to other pipes:
 
 ```python
 def main():
@@ -81,4 +92,3 @@ def main():
         notifier=CustomNotifier()
     )
 ```
-

--- a/learning_pipeline_plugin/algorithms/stream_al.py
+++ b/learning_pipeline_plugin/algorithms/stream_al.py
@@ -101,7 +101,9 @@ class MemoizationSieveStreamingPlusPlusSelector(Generic[T], AbstractStreamSelect
             self.submodular_f.clear_indices([self.current_index])
         self.current_index += 1
 
-    def _updateThresholdsData(self, tau_min: float):
+    def _updateThresholdsData(self, tau_min: float) -> None:
+        if tau_min <= 0:
+            return
         threshold = 1.0
         while threshold > tau_min/(1.0+self.eps):
             if threshold < self.delta and threshold not in self.s_t:

--- a/learning_pipeline_plugin/algorithms/uncertainty.py
+++ b/learning_pipeline_plugin/algorithms/uncertainty.py
@@ -15,7 +15,7 @@ class AbstractUncertainty(Generic[T]):
 
 class PseudoUncertainty(AbstractUncertainty):
     def __call__(self, data: T) -> float:
-        return 0.
+        return 1.
 
 
 class ClassificationUncertainty(AbstractUncertainty[DataSample]):

--- a/learning_pipeline_plugin/collect_pipe.py
+++ b/learning_pipeline_plugin/collect_pipe.py
@@ -38,6 +38,7 @@ class CollectPipeBase(Generic[D], Pipe[D, D]):
         super().__init__()
         self.notifier = notifier
 
+        sender_task.set_notifier(notifier)
         app.register_task(sender_task)
 
         self.select_task = SelectTask(

--- a/learning_pipeline_plugin/notifier.py
+++ b/learning_pipeline_plugin/notifier.py
@@ -16,6 +16,11 @@ class AbstractNotifier:
         raise NotImplementedError
 
 
+class NullNotifier(AbstractNotifier):
+    def notify(self, message: str) -> None:
+        pass
+
+
 class Notifier(AbstractNotifier):
     """
     Simple notifier object.

--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -44,8 +44,9 @@ class SenderTask(AbstractSenderTask[DatedImage]):
 
         Use example:
         ```
-        st = SenderTask(endpoint, Notifier(), {"score_threshold": 0.3})
+        st = SenderTask(pipeline_id)
         app.register_task(st)
+        st.set_notifier(my_notifier)
 
         ...
         st.enqueue((time_stamp, image))

--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -55,11 +55,12 @@ class SenderTask(AbstractSenderTask[DatedImage]):
         self.service_client = ServiceClient()
         self.endpoint_root = endpoint_root
         self.pipeline_id = pipeline_id
-        self.notifier: AbstractNotifier = NullNotifier()  # to be set through `set_notifier()` method called by CollectPipe
+        # notifier to be set through `set_notifier()` method called by CollectPipe
+        self.notifier: AbstractNotifier = NullNotifier()
         self.user_metadata = json.dumps(metadata)
         self.data_collect_token = None
         self._sending_enabled = True
-    
+
     def set_notifier(self, notifier: AbstractNotifier) -> None:
         """Set the notifier used by collect_pipe
         - notifier(AbstractNotifier): message formatter to notify sending success/failure to Actcast

--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -33,13 +33,13 @@ class SenderTask(AbstractSenderTask[DatedImage]):
     def __init__(self,
                  pipeline_id: str,
                  metadata: UserMetadata = {},
-                 endpoint_root: str = "api.autolearner.actcast.io",
+                 endpoint_root: str = "https://api.autolearner.actcast.io",
                  inqueuesize: int = 0):
         """Isolated task used to send data to the Learning pipeline servers.
         - pipeline_id (str): ID of the pipeline to send data to (obtained after created a pipeline)
         - metadata(UserMetadata): JSON-like data that will be stored with the image
                                     (e.g. user may include here some act settings)
-        - endpoint_root(str): endpoint root of the lp API server
+        - endpoint_root(str): endpoint root of the lp API server (https://....)
         - inqueuesize(int): size of the sending queue (default: 0 (no limit))
 
         Use example:

--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -10,7 +10,7 @@ from actfw_core.service_client import ServiceClient
 from PIL.Image import Image
 
 from .actfw_utils import IsolatedTask
-from .notifier import AbstractNotifier
+from .notifier import AbstractNotifier, NullNotifier
 
 T = TypeVar("T")
 UserMetadata = Dict[str, Union[str, int, float, bool]]
@@ -22,23 +22,24 @@ class SendingError(Exception):
 
 
 class AbstractSenderTask(Generic[T], IsolatedTask[T]):
+    def set_notifier(self, notifier: AbstractNotifier) -> None:
+        raise NotImplementedError
+
     def _proc(self, data: T) -> None:
         raise NotImplementedError
 
 
 class SenderTask(AbstractSenderTask[DatedImage]):
     def __init__(self,
-                 endpoint_root: str,
                  pipeline_id: str,
-                 notifier: AbstractNotifier,
-                 metadata: UserMetadata,
+                 metadata: UserMetadata = {},
+                 endpoint_root: str = "api.autolearner.actcast.io",
                  inqueuesize: int = 0):
         """Isolated task used to send data to the Learning pipeline servers.
-        - endpoint_root(str): endpoint root of the lp API server
         - pipeline_id (str): ID of the pipeline to send data to (obtained after created a pipeline)
-        - notifier(AbstractNotifier): message formatter to notify sending success/failure to Actcast
         - metadata(UserMetadata): JSON-like data that will be stored with the image
                                     (e.g. user may include here some act settings)
+        - endpoint_root(str): endpoint root of the lp API server
         - inqueuesize(int): size of the sending queue (default: 0 (no limit))
 
         Use example:
@@ -54,7 +55,7 @@ class SenderTask(AbstractSenderTask[DatedImage]):
         self.service_client = ServiceClient()
         self.endpoint_root = endpoint_root
         self.pipeline_id = pipeline_id
-        self.notifier = notifier
+        self.notifier: AbstractNotifier = NullNotifier()  # to be set through `set_notifier()` method called by CollectPipe
         self.user_metadata = json.dumps(metadata)
         self.data_collect_token = None
         self._sending_enabled = True
@@ -64,6 +65,12 @@ class SenderTask(AbstractSenderTask[DatedImage]):
         if os.environ.get("ACTCAST_GROUP_ID") is None:
             self.notifier.notify("Group ID could not be retrieved, check device firmware")
             self._sending_enabled = False
+    
+    def set_notifier(self, notifier: AbstractNotifier) -> None:
+        """Set the notifier used by collect_pipe
+        - notifier(AbstractNotifier): message formatter to notify sending success/failure to Actcast
+        """
+        self.notifier = notifier
 
     @property
     def data_collect_url(self) -> str:

--- a/poetry.lock
+++ b/poetry.lock
@@ -114,11 +114,11 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 
 [[package]]
 name = "numpy"
@@ -168,6 +168,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pytest"
 version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
@@ -200,6 +208,7 @@ python-versions = ">=3.7, <4"
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
+PySocks = {version = ">=1.5.6,<1.5.7 || >1.5.7", optional = true, markers = "extra == \"socks\""}
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
@@ -224,7 +233,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "types-pillow"
-version = "9.4.0.5"
+version = "9.4.0.12"
 description = "Typing stubs for Pillow"
 category = "dev"
 optional = false
@@ -232,7 +241,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.8"
+version = "2.28.11.13"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -243,7 +252,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.25.4"
+version = "1.26.25.6"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -251,7 +260,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -272,20 +281,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.0, <3.8"
-content-hash = "627fb7dd965a846293e2b78415813ac704971e045cfe88b36d741aeb7c3c16e7"
+content-hash = "529d0c314af7851152b65ba3a599f7f0c5dea59ac1a2390d9241532ccd733ead"
 
 [metadata.files]
 actfw-core = [
@@ -443,8 +452,8 @@ mypy = [
     {file = "mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
 ]
 mypy-extensions = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 numpy = [
     {file = "numpy-1.21.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25"},
@@ -523,6 +532,11 @@ pycodestyle = [
     {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
     {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
 ]
+pysocks = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
 pytest = [
     {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
     {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
@@ -562,26 +576,26 @@ typed-ast = [
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
 ]
 types-pillow = [
-    {file = "types-Pillow-9.4.0.5.tar.gz", hash = "sha256:941cefaac2f5297d7d2a9989633c95b4063112690dc21c965d46bd5a7fff3c76"},
-    {file = "types_Pillow-9.4.0.5-py3-none-any.whl", hash = "sha256:a1d2b3e070b4d852af04f76f018d12bd51abb4abca3b725d91b35e01cda7a2de"},
+    {file = "types-Pillow-9.4.0.12.tar.gz", hash = "sha256:e0074149d5f06d3593c118acc83e353f8542bcc73576ffefb6568eaab5671348"},
+    {file = "types_Pillow-9.4.0.12-py3-none-any.whl", hash = "sha256:b4aaa86b43f53e4d552d2c0381068015121e8990b0369df7c5e3b36fa6266984"},
 ]
 types-requests = [
-    {file = "types-requests-2.28.11.8.tar.gz", hash = "sha256:e67424525f84adfbeab7268a159d3c633862dafae15c5b19547ce1b55954f0a3"},
-    {file = "types_requests-2.28.11.8-py3-none-any.whl", hash = "sha256:61960554baca0008ae7e2db2bd3b322ca9a144d3e80ce270f5fb640817e40994"},
+    {file = "types-requests-2.28.11.13.tar.gz", hash = "sha256:3fd332842e8759ea5f7eb7789df8aa772ba155216ccf10ef4aa3b0e5b42e1b46"},
+    {file = "types_requests-2.28.11.13-py3-none-any.whl", hash = "sha256:94896f6f8e9f3db11e422c6e3e4abbc5d7ccace853eac74b23bdd65eeee3cdee"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.25.4.tar.gz", hash = "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"},
-    {file = "types_urllib3-1.26.25.4-py3-none-any.whl", hash = "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49"},
+    {file = "types-urllib3-1.26.25.6.tar.gz", hash = "sha256:35586727cbd7751acccf2c0f34a88baffc092f435ab62458f10776466590f2d5"},
+    {file = "types_urllib3-1.26.25.6-py3-none-any.whl", hash = "sha256:a6c23c41bd03e542eaee5423a018f833077b51c4bf9ceb5aa544e12b812d5604"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.14-py2.py3-none-any.whl", hash = "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"},
     {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
 ]
 zipp = [
-    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
-    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
+    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Idein/learning-pipeline-plugin"
 [tool.poetry.dependencies]
 python = ">=3.7.0, <3.8"
 actfw-core = "^2.2.0"
-requests = "^2.28.1"
+requests = {extras = ["socks"], version = "^2.28.1"}
 numpy = "~1"
 typing-extensions = "^4.4.0"
 


### PR DESCRIPTION
- add pipeline_id argument to sender_task class constructor
- use pipeline_id in learning pipeline API requests
- change sender_task inputs to facilitate instantiation

