### PR TITLE
notify failure detail for device token request

### DIFF
--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -176,5 +176,5 @@ class SenderTask(AbstractSenderTask[DatedImage]):
             self.data_collect_token = data_collect_token
             self.data_collect_token_expires = time.time() + expires_in
         else:
-            self.notifier.notify(f"Data Collect Token request failure ({resp.status_code})")
+            self.notifier.notify(f"Data Collect Token request failed with status {resp.status_code} (reason: {resp.text})")
             resp.raise_for_status()

--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -176,5 +176,6 @@ class SenderTask(AbstractSenderTask[DatedImage]):
             self.data_collect_token = data_collect_token
             self.data_collect_token_expires = time.time() + expires_in
         else:
-            self.notifier.notify(f"Data Collect Token request failed with status {resp.status_code} (reason: {resp.text})")
+            self.notifier.notify(f"Data Collect Token request failed with status {resp.status_code}"
+                                 f" (reason: {resp.text})")
             resp.raise_for_status()


### PR DESCRIPTION
API now returns failure details in the response body.
With this PR, the returned details are notified to actcast.

(Tested on real device through local install)