### PR TITLE
Extension friendly SenderTask

### DIFF
--- a/learning_pipeline_plugin/sender_task.py
+++ b/learning_pipeline_plugin/sender_task.py
@@ -20,7 +20,7 @@ DatedImage = Tuple[str, Image]
 
 class ServiceClientProtocol(Protocol):
     def rs256(self, payload: bytes) -> str:
-        raise NotImplementedError 
+        raise NotImplementedError
 
 
 class AbstractSenderTask(Generic[T], IsolatedTask[T]):
@@ -38,6 +38,7 @@ class AbstractSenderTask(Generic[T], IsolatedTask[T]):
 
 class SenderTaskGenericDated(Generic[T], AbstractSenderTask[T]):
     ServiceClient: Type[ServiceClientProtocol] = ServiceClient
+
     def __init__(self,
                  pipeline_id: str,
                  metadata: Optional[UserMetadata] = None,
@@ -224,7 +225,6 @@ class SenderTaskGenericDated(Generic[T], AbstractSenderTask[T]):
         result = "Success" if success else "Failure"
         self.notifier.notify(f"SenderTask Result: {result}")
         return success
-
 
 
 class SenderTask(SenderTaskGenericDated[DatedImage]):


### PR DESCRIPTION
~(waiting for #18 )~

Changes the structure of the Sender class (with unchanged behavior) to allow extensions by the user.

Simplified extensions for subclass created by the user:
- adding behavior on success/failure of data send (e.g. creating a counter)
- creating a SenderTask for data of signature Tuple[str, MyImgFormat], requiring only to define two static methods
- using a user implementation of ServiceClient to sign payloads